### PR TITLE
Multicampaign rework

### DIFF
--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -246,6 +246,7 @@ while True:
     elif event.endswith("::delete_campaign"):
         if popup.choice_box(text="Are you sure you want to delete campaign \"{}\"?".format(campaign), window_name="Delete Campaign")==True:
             send2trash(camp_dir)
+            pref["last campaign"].remove(campaign)
             popup.alert_box(text="Campaign deleted", sound=False, window_name="Delete Campaign")
             if len(listdir("campaigns"))!=0: #loads most recent possible campaign
                 for i in pref["last campaign"]:

--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -1,22 +1,66 @@
 import PySimpleGUI as sg
-import console_test as ct
-from os import startfile
+#import console_test as ct
+from os import startfile, listdir, rename, mkdir, rmdir
+from os.path import abspath, exists
 from time import sleep
 from error import error
+import window_layouts as popup
+from database_class import pickler, unpickle
+from default_pref import new_pref
+from tkinter import Tk
+from tkinter.filedialog import askdirectory
+from send2trash import send2trash
 
-VERSION="0.4.0 + DEV"
+VERSION="v0.4.0 + DEV"
 
 
+if "pref.pkl" in listdir():
+    pref=unpickle("pref.pkl")
+    
+else:
+    pref=new_pref
+    pickler("pref.pkl", pref)
+    print("new pref file created")
+    
+campaign=None
+if len(listdir("campaigns"))!=0: #loads most recent possible campaign
+    for i in pref["last campaign"]:
+        if i in listdir("campaigns") and exists("campaigns/{}/{}.pkl".format(i, i)):
+            campaign=i
+            break
+        
+if campaign==None:
+    for file in listdir("campaigns"):
+        if exists("campaigns/{}/{}.pkl".format(file, file)):
+            campaign=file
+print(campaign)        
+if len(listdir("campaigns"))==0 or campaign==None:
+    campaign=popup.create_campaign(first=True)
 
+pref["last campaign"].insert(0, campaign)
+pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
+pickler("pref.pkl", pref)    
+    
+print(pref["last campaign"])
+print(campaign)  
+camp_dir="campaigns/"+campaign
+    
+db=unpickle(camp_dir+"/"+campaign+".pkl")    
+
+
+#pref["theme"]=None
+
+################################################################################
+sg.theme(pref["theme"])
 QT_ENTER_KEY1 =  'special 16777220'
 QT_ENTER_KEY2 =  'special 16777221'
 focused_enter=None
 
-#sg.theme("DarkRed1")
+
 
 menu_dict={
-            "File": ["Open...", "Preferences"],
-            "Help": ["About", "ReadMe::readme", "Source Code::source_code"]
+            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", ["LMoP","SKT"], "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Preferences::preferences"],
+            "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
           }
 
 main_layout=[
@@ -24,11 +68,11 @@ main_layout=[
         
         [sg.Text("Time")],
        
-        [sg.InputText("{}:00".format(ct.db["hour"]),size=(6,1), readonly=True,key="hour_display", tooltip="Time - 24 hour"),   sg.InputText(ct.db["day"], size=(3,1), readonly=True,key="day_display", tooltip="Day of the month"),   sg.InputText(ct.db["tenday"], size=(2,1), readonly=True,key="tenday_display", tooltip="Tenday"),   sg.InputText("{}. {}".format(ct.db["month"][0],ct.db["month"][1]), size=(30,1), readonly=True,key="month_display", tooltip="Month"),   sg.InputText(ct.db["year"], size=(5,1), readonly=True,key="year_display", tooltip="Year - DR")],
+        [sg.InputText("{}:00".format(db.hour),size=(6,1), readonly=True,key="hour_display", tooltip="Time - 24 hour"),   sg.InputText(db.day, size=(3,1), readonly=True,key="day_display", tooltip="Day of the month"),   sg.InputText(db.tenday, size=(2,1), readonly=True,key="tenday_display", tooltip="Tenday"),   sg.InputText("{}. {}".format(db.month[0],db.month[1]), size=(30,1), readonly=True,key="month_display", tooltip="Month"),   sg.InputText(db.year, size=(5,1), readonly=True,key="year_display", tooltip="Year - DR")],
         
-        [sg.Text("Temperature"), sg.InputText(ct.db["temperature"], size=(20,1), readonly=True,key="temp_display"), sg.Text("Precipitation"), sg.InputText(ct.db["precipitation"], size=(6,1), readonly=True,key="precip_display")],
+        [sg.Text("Temperature"), sg.InputText(db.temperature, size=(20,1), readonly=True,key="temp_display"), sg.Text("Precipitation"), sg.InputText(db.precipitation, size=(6,1), readonly=True,key="precip_display")],
         
-        [sg.Text("Wind Speed"), sg.InputText(ct.db["windspeed"], size=(6,1), readonly=True,key="WS_display"), sg.Text("Wind Direction"), sg.InputText(ct.db["wind_dir"], size=(3,1), readonly=True,key="WD_display")],
+        [sg.Text("Wind Speed"), sg.InputText(db.windspeed, size=(6,1), readonly=True,key="WS_display"), sg.Text("Wind Direction"), sg.InputText(db.wind_dir, size=(3,1), readonly=True,key="WD_display")],
        
         [sg.Text("Time Adjustment"), sg.InputText("0", size=(5,1), key="hour_input", tooltip="Hour Change"), sg.InputText("0", size=(5,1), key="day_input", tooltip="Day Change"), sg.Button("Submit")],
         
@@ -37,8 +81,7 @@ main_layout=[
 
 updatable=["hour_display", "day_display", "tenday_display", "month_display", "year_display"]+["temp_display", "precip_display"]+["WS_display", "WD_display"]
 
-window=sg.Window("D&D Time Manager", main_layout, finalize=True, icon="dnd_logo.ico", return_keyboard_events=True)
-
+window=sg.Window("D&D Time Manager - "+campaign, main_layout, finalize=True, icon="dnd_logo.ico", return_keyboard_events=True)
 
 
 
@@ -61,8 +104,8 @@ while True:
         
 
         try:
-            log=open("log.txt", "a")
-            log.write("{} {}/{}/{} - {}\n".format(str(ct.db["hour"])+":00", ct.db["day"], ct.db["month"][0], ct.db["year"], window["log_input"].Get()))
+            log=open("{}/{}.txt".format(camp_dir,campaign), "a")
+            log.write("{} {}/{}/{} - {}\n".format(str(db.hour)+":00", db.day, db.month[0], db.year, window["log_input"].Get()))
             
             log.close()    
             window["log_input"].Update("")
@@ -78,20 +121,21 @@ while True:
             
     elif event == "Open Log":  #opens log file
         try:
-            startfile("log.txt")
-        except:
-            
+            startfile(abspath("{}/{}.txt".format(camp_dir,campaign)))
+        except Exception as e:
+           # print(e)
             try:
-                log=open("log.txt", "a")
+                log=open("{}/{}.txt".format(camp_dir,campaign), "a")
                 log.close()
-                startfile("log.txt")
+                startfile(abspath("{}/{}.txt".format(camp_dir,campaign)))
                 
             except PermissionError as e:
                 print("UNABLE TO LOG")
                 error("Unable to print to log.txt - "+str(e))
-            except:
+            except Exception as e:
+                print(e)
                 print("UNABLE TO OPEN LOG FILE")
-                error("Unable to open log.txt")
+                error("Unable to open {}.txt".format(campaign))
     
     elif event == "Submit" or focused_enter=="time":  #Sumbits changes to database time and updates day conditions
         
@@ -105,10 +149,10 @@ while True:
             error("Invalid time input \"{}, {}\" detected".format(window["hour_input"].Get(),window["day_input"].Get()))
             pass
         else:
-            ct.hour(h)
-            ct.day(d)
-            ct.save()
-            update_values=["{}:00".format(ct.db["hour"]), ct.db["day"], ct.db["tenday"], "{}. {}".format(ct.db["month"][0],ct.db["month"][1]), ct.db["year"]]+[ct.db["temperature"], ct.db["precipitation"]]+[ct.db["windspeed"], ct.db["wind_dir"]]
+            db.change_hour(h)
+            db.change_day(d)
+            pickler(camp_dir+"/"+campaign+".pkl", db)
+            update_values=["{}:00".format(db.hour), db.day, db.tenday, "{}. {}".format(db.month[0],db.month[1]), db.year]+[db.temperature, db.precipitation]+[db.windspeed, db.wind_dir]
       #      ct.show_all()
        #     print("\n")
             for i in range(len(updatable)):
@@ -119,6 +163,133 @@ while True:
     
     
 # Menu Events -----------------------------------------------------------------------
+    
+    elif event.endswith("::new_campaign"):
+        campaign=popup.create_campaign(first=False)
+        print(campaign)
+        
+       # path="campaigns/"+campaign
+        camp_dir="campaigns/"+campaign
+        for file in listdir(camp_dir):
+                if file.endswith(".pkl"):
+                    campaign=file.split(".")[0]
+                    db=unpickle(camp_dir+"/"+file) 
+                    update_values=["{}:00".format(db.hour), db.day, db.tenday, "{}. {}".format(db.month[0],db.month[1]), db.year]+[db.temperature, db.precipitation]+[db.windspeed, db.wind_dir]
+                    break
+        for i in range(len(updatable)):
+            window[updatable[i]].Update(update_values[i])
+        window.set_title("D&D Time Manager - "+campaign)
+        window["hour_input"].Update("0")
+        window["day_input"].Update("0")
+        window["log_input"].Update("")
+        
+        pref["last campaign"].insert(0, campaign)
+        pickler("pref.pkl", pref)
+
+
+
+
+    elif event.endswith("::open_campaign"):
+        Tk().withdraw()
+        try:
+            path=askdirectory(initialdir=abspath("")+"/campaigns")#, title='Please select a directory')
+        except Exception as e:
+            print("Invalid Folder Path\n")
+            print(e)
+            pass
+        else:
+            print(path)
+            for file in listdir(path):
+                if file.endswith(".pkl"):
+                    campaign=file.split(".")[0]
+                    camp_dir="campaigns/"+campaign
+                    db=unpickle(path+"/"+file) 
+                    update_values=["{}:00".format(db.hour), db.day, db.tenday, "{}. {}".format(db.month[0],db.month[1]), db.year]+[db.temperature, db.precipitation]+[db.windspeed, db.wind_dir]
+                    break
+            for i in range(len(updatable)):
+                window[updatable[i]].Update(update_values[i])
+            window.set_title("D&D Time Manager - "+campaign)
+            window["hour_input"].Update("0")
+            window["day_input"].Update("0")
+            window["log_input"].Update("")
+            
+            pref["last campaign"].insert(0, campaign)
+            pickler("pref.pkl", pref)
+            
+        if path=="":
+            print("Invalid Folder Path\n")
+            pass
+
+    elif event.endswith("::rename_campaign"):
+        
+        new_campaign=popup.rename_window(campaign)
+        if new_campaign!=None:
+            try:
+                mkdir(r"campaigns/{}".format(new_campaign))
+                for file in listdir(camp_dir):
+                    file_type=file.split(".")[-1]
+                    rename(r"{}/{}".format(camp_dir,file), r"campaigns/{}/{}.{}".format(new_campaign,new_campaign,file_type))
+            except Exception as e:
+                popup.alert_box(text="Unable to rename capaign")
+                print(e)
+            else:
+                rmdir(camp_dir)
+                campaign=new_campaign
+                camp_dir="campaigns/"+campaign
+                window.set_title("D&D Time Manager - "+campaign)
+                pref["last campaign"].insert(0, campaign)
+                pickler("pref.pkl", pref)
+                popup.alert_box(text="Rename sucessful", sound=False, window_name="Rename")
+            
+            
+            
+    elif event.endswith("::delete_campaign"):
+        if popup.choice_box(text="Are you sure you want to delete campaign \"{}\"?".format(campaign), window_name="Delete Campaign")==True:
+            send2trash(camp_dir)
+            popup.alert_box(text="Campaign deleted", sound=False, window_name="Delete Campaign")
+            if len(listdir("campaigns"))!=0: #loads most recent possible campaign
+                for i in pref["last campaign"]:
+                    if i in listdir("campaigns") and exists("campaigns/{}/{}.pkl".format(i, i)):
+                        campaign=i
+                        break
+                    
+            if campaign==None:
+                for file in listdir("campaigns"):
+                    if exists("campaigns/{}/{}.pkl".format(file, file)):
+                        campaign=file
+            print(campaign)        
+            if len(listdir("campaigns"))==0 or campaign==None:
+                campaign=popup.create_campaign(first=True)
+            
+            pref["last campaign"].insert(0, campaign)
+            pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
+            pickler("pref.pkl", pref)    
+                
+            print(pref["last campaign"])
+            print(campaign)  
+            camp_dir="campaigns/"+campaign            
+            
+            window.set_title("D&D Time Manager - "+campaign)
+            db=unpickle(camp_dir+"/"+campaign+".pkl")   
+            update_values=["{}:00".format(db.hour), db.day, db.tenday, "{}. {}".format(db.month[0],db.month[1]), db.year]+[db.temperature, db.precipitation]+[db.windspeed, db.wind_dir]
+                    
+            for i in range(len(updatable)):
+                window[updatable[i]].Update(update_values[i])
+            window.set_title("D&D Time Manager - "+campaign)
+            window["hour_input"].Update("0")
+            window["day_input"].Update("0")
+            window["log_input"].Update("")
+            
+            pref["last campaign"].insert(0, campaign)
+            pickler("pref.pkl", pref)
+        
+    
+    elif event.endswith("::preferences"):
+        pass
+    
+    elif event.endswith("::about"):
+        about_text="D&D Time Manager\nVersion: {}".format(VERSION)
+        popup.alert_box(text=about_text, window_name="About", button_text="Close", sound=False)
     
     elif event.endswith("::readme"):
         try:
@@ -135,8 +306,10 @@ while True:
             startfile("https://github.com/JP-Carr/DnD_Time_Manager")  
         except:
             pass
-   # else:
-    #    print (event)  
+        
+    
+  #  else:
+   #     print (event)  
        
 
 window.close()

--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -39,6 +39,8 @@ if len(listdir("campaigns"))==0 or campaign==None:
 
 pref["last campaign"].insert(0, campaign)
 pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
+recent_camps=pref["last campaign"][0:3]
+#window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
 pickler("pref.pkl", pref)    
     
 print(pref["last campaign"])
@@ -59,12 +61,12 @@ focused_enter=None
 
 
 menu_dict={
-            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", ["LMoP","SKT"], "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Preferences::preferences"],
+            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Preferences::preferences"],
             "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
           }
 
 main_layout=[
-        [sg.Menu([[i,menu_dict[i]] for i in menu_dict], visible=False)],
+        [sg.Menu([[i,menu_dict[i]] for i in menu_dict], visible=False, key="menu_bar")],
         
         [sg.Text("Time")],
        
@@ -184,6 +186,13 @@ while True:
         window["log_input"].Update("")
         
         pref["last campaign"].insert(0, campaign)
+        pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
+        recent_camps=pref["last campaign"][0:3]
+        menu_dict={
+            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Preferences::preferences"],
+            "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
+          }
+        window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
         pickler("pref.pkl", pref)
 
 
@@ -214,6 +223,13 @@ while True:
             window["log_input"].Update("")
             
             pref["last campaign"].insert(0, campaign)
+            pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
+            recent_camps=pref["last campaign"][0:3]
+            menu_dict={
+            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Preferences::preferences"],
+            "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
+          }
+            window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
             pickler("pref.pkl", pref)
             
         if path=="":
@@ -238,6 +254,13 @@ while True:
                 camp_dir="campaigns/"+campaign
                 window.set_title("D&D Time Manager - "+campaign)
                 pref["last campaign"].insert(0, campaign)
+                pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
+                recent_camps=pref["last campaign"][0:3]
+                menu_dict={
+            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Preferences::preferences"],
+            "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
+          }
+                window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
                 pickler("pref.pkl", pref)
                 popup.alert_box(text="Rename sucessful", sound=False, window_name="Rename")
             
@@ -264,6 +287,12 @@ while True:
             
             pref["last campaign"].insert(0, campaign)
             pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
+            recent_camps=pref["last campaign"][0:3]
+            menu_dict={
+            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Preferences::preferences"],
+            "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
+          }
+            window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
             pickler("pref.pkl", pref)    
                 
             print(pref["last campaign"])
@@ -282,6 +311,14 @@ while True:
             window["log_input"].Update("")
             
             pref["last campaign"].insert(0, campaign)
+            pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
+            recent_camps=pref["last campaign"][0:3]
+            menu_dict={
+            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Preferences::preferences"],
+            "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
+          }
+            window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
+            
             pickler("pref.pkl", pref)
         
     
@@ -308,6 +345,33 @@ while True:
         except:
             pass
         
+    elif event in recent_camps:
+        
+        if event!=campaign:
+            print(0)
+            camp_dir="campaigns/"+event
+            for file in listdir(camp_dir):
+                    if file.endswith(".pkl"):
+                        campaign=file.split(".")[0]
+                        db=unpickle(camp_dir+"/"+file) 
+                        update_values=["{}:00".format(db.hour), db.day, db.tenday, "{}. {}".format(db.month[0],db.month[1]), db.year]+[db.temperature, db.precipitation]+[db.windspeed, db.wind_dir]
+                        break
+            for i in range(len(updatable)):
+                window[updatable[i]].Update(update_values[i])
+            window.set_title("D&D Time Manager - "+campaign)
+            window["hour_input"].Update("0")
+            window["day_input"].Update("0")
+            window["log_input"].Update("")
+            
+            pref["last campaign"].insert(0, campaign)
+            pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
+            recent_camps=pref["last campaign"][0:3]
+            menu_dict={
+                "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Preferences::preferences"],
+                "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
+              }
+            window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
+            pickler("pref.pkl", pref)
     
   #  else:
    #     print (event)  

--- a/database_class.py
+++ b/database_class.py
@@ -1,0 +1,122 @@
+import pickle
+from random import choice, randint
+import condition_lists as conditions
+########################################################
+
+class db:
+    
+    def __init__(self):
+        print("Initalising database...")
+        """
+        self.day_data={"day_raw":0,
+              "day": 1,
+              "hour":0,
+              "tenday":1,
+              "month":[1,conditions.months[1]],
+              "year":1491,
+              "precipitation": choice(conditions.precipitation),
+              "wind_dir": choice(conditions.wind_dir),
+              "windspeed": choice(conditions.wind_speed),
+              "temperature": choice(conditions.temp)
+              } 
+        """
+        self.day_raw=0
+        self.day=1
+        self.hour=0
+        self.tenday=1
+        self.month=[1,conditions.months[1]]
+        self.year=1491
+        self.precipitation= choice(conditions.precipitation)
+        self.wind_dir=choice(conditions.wind_dir)
+        self.windspeed=choice(conditions.wind_speed)
+        self.temperature= choice(conditions.temp)
+  #      pickle.dump( self.day_data, open("db.pkl", "wb"))
+    """
+    def save():
+        try:
+            pickle.dump( db, open("db.pkl", "wb"))
+        except:
+            print("UNABLE TO SAVE DATABASE")
+        else:
+            print("Database saved")
+    """    
+    
+    def show_all(self):
+        for i in db:
+           print("{}: {}".format(i,self.day_data[i]))
+           
+    def next_day(self, days=1):
+        for i in range(abs(days)):
+            x=[randint(0,5) for i in range(4)]
+            if x[0]==0:
+                self.precipitation=choice(conditions.precipitation)
+            if x[1]==0:
+                self.wind_dir=choice(conditions.wind_dir)
+            if x[2]==0:
+                self.windspeed=choice(conditions.wind_speed)
+            if x[3]==0:
+                self.temperature=choice(conditions.temp)
+        
+        self.day=self.day_raw%30+1
+        self.tenday=int((self.day_raw%30)/10)+1
+        m=int((self.day_raw%360)/30)+1
+        self.month=[m,conditions.months[m]]
+        self.year=int(self.day_raw/360)+1491
+        
+        
+    def change_day(self, x):
+        #x=input("Enter number of days to pass:\n>>")
+        try:
+            self.day_raw+=int(x)
+            if int(x)!=0:
+                self.next_day(int(x))
+                
+        except TypeError as e:
+            print("INVALID TIME INCREMENT")
+           
+    def change_hour(self, x):
+       # x=input("Enter number of hours to pass:\n>>")
+        try:
+            self.hour+=int(x)
+            while self.hour>=24:
+                self.hour-=24
+                self.day_raw+=1
+                self.next_day()
+            while self.hour<0:
+                self.hour+=24
+                self.day_raw-=1
+                self.next_day(-1)
+            print("Time: {}:00".format(self.hour))
+        except TypeError as e:
+            print("INVALID TIME INCREMENT")
+
+
+def pickler(path,obj):
+    outfile = open(path,'wb')
+    pickle.dump(obj,outfile)
+    outfile.close()
+    print(path+" pickled")
+    
+def unpickle(path):
+    try:    
+        infile = open(path,'rb')
+        obj = pickle.load(infile)
+        infile.close()
+        print(path+" unpickled")
+        return obj
+    except FileNotFoundError:
+        return None
+
+     
+###########################################################
+"""
+try:
+    db=pickle.load(open( "db.pkl", "rb" ) )
+except:
+    init()    
+    db=pickle.load(open( "db.pkl", "rb" ) )
+
+#while 1:    
+#    x=input("Enter command:\n>>")
+#    commands(x)
+"""

--- a/default_pref.py
+++ b/default_pref.py
@@ -1,0 +1,4 @@
+new_pref={"last campaign": [],
+          "theme": None
+      
+      }

--- a/window_layouts.py
+++ b/window_layouts.py
@@ -4,13 +4,18 @@ from os import listdir, mkdir
 from database_class import db, pickler
 from sys import exit
 
+QT_ENTER_KEY1 =  'special 16777220'
+QT_ENTER_KEY2 =  'special 16777221'
+
+icon_path="dnd_logo.ico"
+
 def alert_box(text="TEXT HERE", window_name="ALERT", button_text="OK", sound=True, theme=None):
     sg.theme(theme)
     layout=[
             [sg.Text("  "+text+"  ")],
             [sg.Button(button_text)]
             ]
-    window=sg.Window(window_name, layout, finalize=True, icon=None, element_justification="center", force_toplevel=True,disable_minimize=True)
+    window=sg.Window(window_name, layout, finalize=True, icon=icon_path, element_justification="center", force_toplevel=True,disable_minimize=True, return_keyboard_events=True, )
     if sound==True:
         print("\a")
     
@@ -19,7 +24,7 @@ def alert_box(text="TEXT HERE", window_name="ALERT", button_text="OK", sound=Tru
         if event == sg.WIN_CLOSED:
             window.close()
             return
-        elif event==button_text:
+        elif event==button_text or event in ('\r', QT_ENTER_KEY1, QT_ENTER_KEY2):
             window.close()
             return
             
@@ -30,7 +35,7 @@ def choice_box(text, window_name="", theme=None):
             [sg.Text(text)],
             [sg.Button("Yes"), sg.Button("No")]
             ]
-    window=sg.Window(window_name, layout, finalize=True, icon=None, element_justification="center", force_toplevel=True,disable_minimize=True)
+    window=sg.Window(window_name, layout, finalize=True, icon=icon_path, element_justification="center", force_toplevel=True,disable_minimize=True, )
     print("\a")
     
     while True:
@@ -53,10 +58,20 @@ def create_campaign(first=False, theme=None):
             [sg.Text("Name"), sg.InputText("", size=(25,1), key="campaign_name")],
             [sg.Button("Create")]
             ]
-    window=sg.Window("New...", layout, finalize=True, icon=None, element_justification="center", force_toplevel=True,disable_minimize=False)
+    window=sg.Window("New...", layout, finalize=True, icon=icon_path, element_justification="center", force_toplevel=True,disable_minimize=False, return_keyboard_events=True, )
 
     while True:
         event, values = window.read()
+        focused_enter=None
+     #   print(event)
+        if event in ('\r', QT_ENTER_KEY1, QT_ENTER_KEY2):
+            active_element=window.FindElementWithFocus()          #Dectects if the enter key has been pressed and checks which element is active
+            print(active_element)
+            
+            if active_element==window["campaign_name"]:
+                focused_enter="campaign_name"
+
+        
         if event == sg.WIN_CLOSED and first==False:
             window.close()
             return 
@@ -65,7 +80,7 @@ def create_campaign(first=False, theme=None):
             exit()
             return
         
-        elif event=="Create":
+        elif event=="Create" or focused_enter=="campaign_name":
             name=window["campaign_name"].Get()
             
             try:
@@ -77,7 +92,7 @@ def create_campaign(first=False, theme=None):
                     
                     new_db=db()
                     mkdir(_dir)
-                    pickler(_dir+"/{}.pkl".format(name,name), new_db)
+                    pickler(_dir+"/{}.pkl".format(name), new_db)
                     
                     window.close()
                     return name
@@ -98,15 +113,25 @@ def rename_window(old_name, theme=None):
             [sg.Button("Confirm"), sg.Button("Cancel")]
             ]
     
-    window=sg.Window("Rename", layout, finalize=True, icon=None, element_justification="center", force_toplevel=True,disable_minimize=False)
+    window=sg.Window("Rename", layout, finalize=True, icon=icon_path, element_justification="center", force_toplevel=True,disable_minimize=False, return_keyboard_events=True)
   
     while True:
         event, values = window.read()
+        
+        focused_enter=None
+     #   print(event)
+        if event in ('\r', QT_ENTER_KEY1, QT_ENTER_KEY2):
+            active_element=window.FindElementWithFocus()          #Dectects if the enter key has been pressed and checks which element is active
+            print(active_element)
+            
+            if active_element==window["campaign_name"]:
+                focused_enter="campaign_name"
+        
         if event == sg.WIN_CLOSED:
             window.close()
             return 
 
-        elif event=="Confirm":
+        elif event=="Confirm" or focused_enter=="campaign_name":
             name=window["campaign_name"].Get()
             if name!="" and name not in listdir():
                 window.close()

--- a/window_layouts.py
+++ b/window_layouts.py
@@ -1,0 +1,120 @@
+import PySimpleGUI as sg
+from time import sleep
+from os import listdir, mkdir
+from database_class import db, pickler
+from sys import exit
+
+def alert_box(text="TEXT HERE", window_name="ALERT", button_text="OK", sound=True, theme=None):
+    sg.theme(theme)
+    layout=[
+            [sg.Text("  "+text+"  ")],
+            [sg.Button(button_text)]
+            ]
+    window=sg.Window(window_name, layout, finalize=True, icon=None, element_justification="center", force_toplevel=True,disable_minimize=True)
+    if sound==True:
+        print("\a")
+    
+    while True:
+        event, values = window.read()
+        if event == sg.WIN_CLOSED:
+            window.close()
+            return
+        elif event==button_text:
+            window.close()
+            return
+            
+
+def choice_box(text, window_name="", theme=None):
+    sg.theme(theme)
+    layout=[
+            [sg.Text(text)],
+            [sg.Button("Yes"), sg.Button("No")]
+            ]
+    window=sg.Window(window_name, layout, finalize=True, icon=None, element_justification="center", force_toplevel=True,disable_minimize=True)
+    print("\a")
+    
+    while True:
+        event, values = window.read()
+        if event == sg.WIN_CLOSED:
+            window.close()
+            return False
+        elif event=="No":
+            window.close()
+            return False
+        elif event=="Yes":
+            window.close()
+            return True
+        
+def create_campaign(first=False, theme=None):
+    sg.theme(theme)
+    layout=[
+            [sg.Text("New Campaign")],
+            [sg.HorizontalSeparator(color="gray")],
+            [sg.Text("Name"), sg.InputText("", size=(25,1), key="campaign_name")],
+            [sg.Button("Create")]
+            ]
+    window=sg.Window("New...", layout, finalize=True, icon=None, element_justification="center", force_toplevel=True,disable_minimize=False)
+
+    while True:
+        event, values = window.read()
+        if event == sg.WIN_CLOSED and first==False:
+            window.close()
+            return 
+        elif event == sg.WIN_CLOSED and first==True:
+            window.close()
+            exit()
+            return
+        
+        elif event=="Create":
+            name=window["campaign_name"].Get()
+            
+            try:
+                if name in listdir("campaigns"):
+                    alert_box(text="Campaign \"{}\" already exists".format(name))
+                    pass
+                else:
+                    _dir="campaigns/{}".format(name)
+                    
+                    new_db=db()
+                    mkdir(_dir)
+                    pickler(_dir+"/{}.pkl".format(name,name), new_db)
+                    
+                    window.close()
+                    return name
+            except:
+                alert_box(text="\"{}\" is not a valid campaign name".format(name))
+                pass
+                
+def pref_window(theme=None):
+    themes=[None, "Black", "DarkRed1"]
+    
+    
+def rename_window(old_name, theme=None):
+    sg.theme(theme)
+    layout=[
+            [sg.Text("Rename Campaign - "+old_name)],
+            [sg.HorizontalSeparator(color="gray")],
+            [sg.Text("New name"), sg.InputText("", size=(25,1), key="campaign_name")],
+            [sg.Button("Confirm"), sg.Button("Cancel")]
+            ]
+    
+    window=sg.Window("Rename", layout, finalize=True, icon=None, element_justification="center", force_toplevel=True,disable_minimize=False)
+  
+    while True:
+        event, values = window.read()
+        if event == sg.WIN_CLOSED:
+            window.close()
+            return 
+
+        elif event=="Confirm":
+            name=window["campaign_name"].Get()
+            if name!="" and name not in listdir():
+                window.close()
+                return name
+            else:
+                if name in listdir():                 
+                    alert_box(text="Campaign \"{}\" already exists".format(name))
+                    pass
+                    
+        elif event=="Cancel":
+            window.close()


### PR DESCRIPTION
-  added the ability to switch between campaigns with separate databases and logs
    - campaign creation/deletion
    - campaign rename
    - load recent campaigns
-  added menu bar to contain campaign switching functions and links to github
-  added icons to auxiliary windows 
- new class to manage database
- added preferences file to keep settings cross-campaign 