### PR TITLE
Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 *.pkl
 log.txt
 error_log.txt
+/campaigns

--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -57,6 +57,10 @@ while True:
             log.close()    
             window["log_input"].Update("")
             
+        except PermissionError as e:
+            print("UNABLE TO LOG")
+            error("Unable to print to log.txt - "+str(e))
+            
         except:
             print("UNABLE TO LOG")
             error("Unable to print to log.txt")
@@ -71,6 +75,10 @@ while True:
                 log=open("log.txt", "a")
                 log.close()
                 startfile("log.txt")
+                
+            except PermissionError as e:
+                print("UNABLE TO LOG")
+                error("Unable to print to log.txt - "+str(e))
             except:
                 print("UNABLE TO OPEN LOG FILE")
                 error("Unable to open log.txt")

--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -10,16 +10,17 @@ from default_pref import new_pref
 from tkinter import Tk
 from tkinter.filedialog import askdirectory
 from send2trash import send2trash
+#import custom_themes
 
 VERSION="v0.4.0 + DEV"
 
-
 def update_menu():
+
     global recent_camps, menu_dict, window
     
     recent_camps=pref["last campaign"][0:3]
     menu_dict={
-        "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Open save directory...::save_directory", ],#"Preferences::preferences"],
+        "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Open save directory...::save_directory", "Preferences::preferences"],
         "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
       }
     try:
@@ -54,7 +55,7 @@ if campaign==None:
             campaign=file
 print(campaign)        
 if len(listdir("campaigns"))==0 or campaign==None:
-    campaign=popup.create_campaign(first=True)
+    campaign=popup.create_campaign(first=True, theme=pref["theme"])
 
 pref["last campaign"].insert(0, campaign)
 pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
@@ -68,15 +69,14 @@ camp_dir="campaigns/"+campaign
     
 db=unpickle(camp_dir+"/"+campaign+".pkl")    
 
-
-#pref["theme"]=None
+#pref["theme"]="Fighter"
 
 ################################################################################
+
 sg.theme(pref["theme"])
 QT_ENTER_KEY1 =  'special 16777220'
 QT_ENTER_KEY2 =  'special 16777221'
 focused_enter=None
-
 
 #menu_dict={
  #           "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Open save directory...::save_directory", "Preferences::preferences"],
@@ -190,7 +190,7 @@ while True:
 # Menu Events -----------------------------------------------------------------------
     
     elif event.endswith("::new_campaign"):
-        campaign=popup.create_campaign(first=False)
+        campaign=popup.create_campaign(first=False, theme=pref["theme"])
         
         if campaign!=None:
             print(campaign)
@@ -210,14 +210,7 @@ while True:
             
             pref["last campaign"].insert(0, campaign)
             pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
-            """
-            recent_camps=pref["last campaign"][0:3]
-            menu_dict={
-                "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Open save directory...::save_directory", "Preferences::preferences"],
-                "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
-              }
-            window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
-            """
+
             update_menu()
             pickler("pref.pkl", pref)
 
@@ -256,14 +249,7 @@ while True:
                 
                 pref["last campaign"].insert(0, campaign)
                 pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
-                """
-                recent_camps=pref["last campaign"][0:3]
-                menu_dict={
-                "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Open save directory...::save_directory", "Preferences::preferences"],
-                "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
-              }
-                window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
-                """
+
                 update_menu()
                 pickler("pref.pkl", pref)
             
@@ -273,7 +259,7 @@ while True:
 
     elif event.endswith("::rename_campaign"):
         
-        new_campaign=popup.rename_window(campaign)
+        new_campaign=popup.rename_window(campaign, theme=pref["theme"])
         if new_campaign!=None:
             try:
                 mkdir(r"campaigns/{}".format(new_campaign))
@@ -281,7 +267,7 @@ while True:
                     file_type=file.split(".")[-1]
                     rename(r"{}/{}".format(camp_dir,file), r"campaigns/{}/{}.{}".format(new_campaign,new_campaign,file_type))
             except Exception as e:
-                popup.alert_box(text="Unable to rename capaign")
+                popup.alert_box(text="Unable to rename capaign", theme=pref["theme"])
                 print(e)
             else:
                 rmdir(camp_dir)
@@ -292,25 +278,18 @@ while True:
                 pref["last campaign"].insert(0, campaign)
                 pref["last campaign"].remove(old_campaign)
                 pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
-                """
-                recent_camps=pref["last campaign"][0:3]
-                menu_dict={
-            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Open save directory...::save_directory", "Preferences::preferences"],
-            "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
-          }
-                window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
-                """
+
                 update_menu()
                 pickler("pref.pkl", pref)
-                popup.alert_box(text="Rename sucessful", sound=False, window_name="Rename")
+                popup.alert_box(text="Rename sucessful", sound=False, window_name="Rename", theme=pref["theme"])
             
             
             
     elif event.endswith("::delete_campaign"):
-        if popup.choice_box(text="Are you sure you want to delete campaign \"{}\"?".format(campaign), window_name="Delete Campaign")==True:
+        if popup.choice_box(text="Are you sure you want to delete campaign \"{}\"?".format(campaign), window_name="Delete Campaign", theme=pref["theme"])==True:
             send2trash(camp_dir)
             pref["last campaign"].remove(campaign)
-            popup.alert_box(text="Campaign deleted", sound=False, window_name="Delete Campaign")
+            popup.alert_box(text="Campaign deleted", sound=False, window_name="Delete Campaign", theme=pref["theme"])
             if len(listdir("campaigns"))!=0: #loads most recent possible campaign
                 for i in pref["last campaign"]:
                     if i in listdir("campaigns") and exists("campaigns/{}/{}.pkl".format(i, i)):
@@ -323,18 +302,11 @@ while True:
                         campaign=file
             print(campaign)        
             if len(listdir("campaigns"))==0 or campaign==None:
-                campaign=popup.create_campaign(first=True)
+                campaign=popup.create_campaign(first=True, theme=pref["theme"])
             
             pref["last campaign"].insert(0, campaign)
             pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
-            """
-            recent_camps=pref["last campaign"][0:3]
-            menu_dict={
-            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Open save directory...::save_directory", "Preferences::preferences"],
-            "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
-          }
-            window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
-            """
+
             update_menu()
             pickler("pref.pkl", pref)    
                 
@@ -356,14 +328,7 @@ while True:
             
             pref["last campaign"].insert(0, campaign)
             pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
-            """
-            recent_camps=pref["last campaign"][0:3]
-            menu_dict={
-            "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Open save directory...::save_directory", "Preferences::preferences"],
-            "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
-          }
-            window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
-            """
+
             update_menu()
             pickler("pref.pkl", pref)
             
@@ -373,12 +338,15 @@ while True:
     
     
     elif event.endswith("::preferences"):
-        pass
-    
+        pref, save_pref = popup.pref_window(pref, theme=pref["theme"])
+        if save_pref==True:
+            pickler("pref.pkl", pref)
+        #print(pref["theme"])
+        
     
     elif event.endswith("::about"):
         about_text="D&D Time Manager\nVersion: {}".format(VERSION)
-        popup.alert_box(text=about_text, window_name="About", button_text="Close", sound=False)
+        popup.alert_box(text=about_text, window_name="About", button_text="Close", sound=False, theme=pref["theme"])
     
     
     elif event.endswith("::readme"):
@@ -414,16 +382,8 @@ while True:
                         break
             except FileNotFoundError:
                 pref["last campaign"].remove(event)
-                """
-                recent_camps=pref["last campaign"][0:3]
-                menu_dict={
-                    "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Open save directory...::save_directory", "Preferences::preferences"],
-                    "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
-                    }
-                window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
-                """
                 update_menu()
-                popup.alert_box("Unable to load campaign \"{}\"".format(event))
+                popup.alert_box("Unable to load campaign \"{}\"".format(event), theme=pref["theme"])
                 
             except Exception as e:
                 print(e)
@@ -438,20 +398,13 @@ while True:
                 
                 pref["last campaign"].insert(0, campaign)
                 pref["last campaign"]=list(dict.fromkeys(pref["last campaign"]))
-                """
-                recent_camps=pref["last campaign"][0:3]
-                menu_dict={
-                    "File": ["New campaign...::new_campaign", "Open...::open_campaign", "Open recent", recent_camps, "Rename campaign::rename_campaign", "Delete campaign::delete_campaign", "Open save directory...::save_directory", "Preferences::preferences"],
-                    "Help": ["About::about", "ReadMe::readme", "Source Code::source_code"]
-                  }
-                window["menu_bar"].Update(menu_definition=[[i,menu_dict[i]] for i in menu_dict])
-                """
+
                 update_menu()
                 pickler("pref.pkl", pref)
     
   #  else:
    #     print (event)  
        
-       
-
+pref["theme"]=pref["new_theme"]   
+pickler("pref.pkl", pref)
 window.close()

--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -4,14 +4,24 @@ from os import startfile
 from time import sleep
 from error import error
 
+VERSION="0.4.0 + DEV"
+
+
+
 QT_ENTER_KEY1 =  'special 16777220'
 QT_ENTER_KEY2 =  'special 16777221'
-
 focused_enter=None
 
 #sg.theme("DarkRed1")
 
-layout=[
+menu_dict={
+            "File": ["Open...", "Preferences"],
+            "Help": ["About", "ReadMe::readme", "Source Code::source_code"]
+          }
+
+main_layout=[
+        [sg.Menu([[i,menu_dict[i]] for i in menu_dict], visible=False)],
+        
         [sg.Text("Time")],
        
         [sg.InputText("{}:00".format(ct.db["hour"]),size=(6,1), readonly=True,key="hour_display", tooltip="Time - 24 hour"),   sg.InputText(ct.db["day"], size=(3,1), readonly=True,key="day_display", tooltip="Day of the month"),   sg.InputText(ct.db["tenday"], size=(2,1), readonly=True,key="tenday_display", tooltip="Tenday"),   sg.InputText("{}. {}".format(ct.db["month"][0],ct.db["month"][1]), size=(30,1), readonly=True,key="month_display", tooltip="Month"),   sg.InputText(ct.db["year"], size=(5,1), readonly=True,key="year_display", tooltip="Year - DR")],
@@ -22,12 +32,12 @@ layout=[
        
         [sg.Text("Time Adjustment"), sg.InputText("0", size=(5,1), key="hour_input", tooltip="Hour Change"), sg.InputText("0", size=(5,1), key="day_input", tooltip="Day Change"), sg.Button("Submit")],
         
-        [sg.InputText(size=(40,1), key="log_input", tooltip="Log Input"), sg.Button("Log"), sg.Button("Open Log")]
+        [sg.InputText(size=(40,1), key="log_input", tooltip="Log Input"), sg.Button("Log"), sg.VerticalSeparator(color="gray"), sg.Button("Open Log")]
         ]
 
 updatable=["hour_display", "day_display", "tenday_display", "month_display", "year_display"]+["temp_display", "precip_display"]+["WS_display", "WD_display"]
 
-window=sg.Window("D&D Time Manager", layout, finalize=True, icon="dnd_logo.ico", return_keyboard_events=True)
+window=sg.Window("D&D Time Manager", main_layout, finalize=True, icon="dnd_logo.ico", return_keyboard_events=True)
 
 
 
@@ -104,12 +114,29 @@ while True:
             for i in range(len(updatable)):
                 window[updatable[i]].Update(update_values[i])
         window["hour_input"].Update("0")
-        window["day_input"].Update("0")    
+        window["day_input"].Update("0")
     
     
     
+# Menu Events -----------------------------------------------------------------------
+    
+    elif event.endswith("::readme"):
+        try:
+            startfile("https://github.com/JP-Carr/DnD_Time_Manager/blob/master/README.md")  
+        except:
+            try:
+                startfile("README.md")
+            except:
+                pass
+    
+
+    elif event.endswith("::source_code"):
+        try:
+            startfile("https://github.com/JP-Carr/DnD_Time_Manager")  
+        except:
+            pass
    # else:
-   #     print ("|{}|".format(event))  
+    #    print (event)  
        
 
 window.close()

--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -38,6 +38,9 @@ else:
     pickler("pref.pkl", pref)
     print("new pref file created")
     
+if "campaigns" not in listdir():
+    mkdir("campaigns")
+    
 campaign=None
 if len(listdir("campaigns"))!=0: #loads most recent possible campaign
     for i in pref["last campaign"]:

--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -96,6 +96,8 @@ main_layout=[
         
         [sg.Text("Wind Speed"), sg.InputText(db.windspeed, size=(6,1), readonly=True,key="WS_display"), sg.Text("Wind Direction"), sg.InputText(db.wind_dir, size=(3,1), readonly=True,key="WD_display")],
        
+        [sg.HorizontalSeparator( pad=((0,0),(8,4)))],
+       
         [sg.Text("Time Adjustment"), sg.InputText("0", size=(5,1), key="hour_input", tooltip="Hour Change"), sg.InputText("0", size=(5,1), key="day_input", tooltip="Day Change"), sg.Button("Submit")],
         
         [sg.InputText(size=(40,1), key="log_input", tooltip="Log Input"), sg.Button("Log"), sg.VerticalSeparator(color="gray"), sg.Button("Open Log")]

--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -72,7 +72,7 @@ while True:
             d=int(window["day_input"].Get())
         except:
             print("INVALID ENTRY")
-            error("Invalid time input detected")
+            error("Invalid time input \"{}, {}\" detected".format(window["hour_input"].Get(),window["day_input"].Get()))
             pass
         else:
             ct.hour(h)
@@ -83,8 +83,8 @@ while True:
             print("\n")
             for i in range(len(updatable)):
                 window[updatable[i]].Update(update_values[i])
-            window["hour_input"].Update("0")
-            window["day_input"].Update("0")    
+        window["hour_input"].Update("0")
+        window["day_input"].Update("0")    
     else:
         print (event)
 

--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -72,7 +72,7 @@ while True:
             d=int(window["day_input"].Get())
         except:
             print("INVALID ENTRY")
-            error("Invalid log input detected")
+            error("Invalid time input detected")
             pass
         else:
             ct.hour(h)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# DnD_day_tracker
+# D&D Day Tracker
+D&D Day Tracker is a simple application created for Microsoft Windows to allow Dungeon Masters to keep track of in game events and the times at which they occured. It also automates the rolling of local weather conditions as outlined in ch. 5 of the the Dungeon Master's Guide (with a few small tweaks).
+
+## Installation
+At present D&DDT is only available  as a standalone .zip archive for Microsoft Windows. Download the [Latest Release](https://github.com/JP-Carr/DnD_Time_Manager/releases/latest), simply unzip the archive in your chosen directory and you're good to go.
+
+## Usage
+To start the program, run "DnD_Time_Manager.exe". This will present you with the app's GUI:
+![GUI_v0.3.0](https://github.com/JP-Carr/DnD_Time_Manager/blob/media/Images/GUI/GUI_0.3.0.JPG)
+#### Layout
+* Row 1 - In game time: Time(hh:mm), Day, Tenday, Month, Year
+* Row 2 - Temperature and precipitation level
+* Row 3 - Wind Speed and direction
+* Row 4 - Hour change input, Day change input, Submit time change (change can be any positive or negative integer)
+* Row 5 - Log input box, Enter log, open log.txt
+-----------------------------------

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
-# D&D Day Tracker
-D&D Day Tracker is a simple application created for Microsoft Windows to allow Dungeon Masters to keep track of in game events and the times at which they occured. It also automates the rolling of local weather conditions as outlined in ch. 5 of the the Dungeon Master's Guide (with a few small tweaks).
+# D&D Time Manager
+D&D Time Manager is a simple application created for Microsoft Windows to allow Dungeon Masters to keep track of in-game events and the times at which they occured. It also automates the rolling of local weather conditions as outlined in ch. 5 of the the Dungeon Master's Guide (with a few small tweaks).
 
 ## Installation
-At present D&DDT is only available  as a standalone .zip archive for Microsoft Windows. Download the [Latest Release](https://github.com/JP-Carr/DnD_Time_Manager/releases/latest), simply unzip the archive in your chosen directory and you're good to go.
+At present D&DTM is only available  as a standalone .zip archive for Microsoft Windows. Download the [Latest Release](https://github.com/JP-Carr/DnD_Time_Manager/releases/latest), simply unzip the archive in your chosen directory and you're good to go.
 
 ## Usage
 To start the program, run "DnD_Time_Manager.exe". This will present you with the app's GUI:
 ![GUI_v0.3.0](https://github.com/JP-Carr/DnD_Time_Manager/blob/media/Images/GUI/GUI_0.3.0.JPG)
 #### Layout
-* Row 1 - In game time: Time(hh:mm), Day, Tenday, Month, Year
+* Row 1 - In-game time: Time(hh:mm), Day, Tenday, Month, Year
 * Row 2 - Temperature and precipitation level
 * Row 3 - Wind Speed and direction
 * Row 4 - Hour change input, Day change input, Submit time change (change can be any positive or negative integer)
 * Row 5 - Log input box, Enter log, open log.txt
 -----------------------------------
+Entering values in the time input boxes and clicking "Submit" will update the in-game time. Weather conditions are automatically rolled on a day change.
+The "Log" function allows for notes to be recorded from the GUI, the log is stored alongside the in-game time and date for easy reference.
+
+## Disclaimer
+This is an unofficial piece of software and is in no way endorsed or sponsored by [Wizards of the Coast](https://company.wizards.com/)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ At present D&DTM is only available  as a standalone .zip archive for Microsoft W
 
 ## Usage
 To start the program, run "DnD_Time_Manager.exe". This will present you with the app's GUI:
-![GUI_v0.3.0](https://github.com/JP-Carr/DnD_Time_Manager/blob/media/Images/GUI/GUI_0.3.0.JPG)
+![GUI_v0.5.0](https://github.com/JP-Carr/DnD_Time_Manager/blob/media/Images/GUI/GUI_0.5.0.JPG)
 #### Layout
 * Row 1 - In-game time: Time(hh:mm), Day, Tenday, Month, Year
 * Row 2 - Temperature and precipitation level
@@ -16,6 +16,19 @@ To start the program, run "DnD_Time_Manager.exe". This will present you with the
 -----------------------------------
 Entering values in the time input boxes and clicking "Submit" will update the in-game time. Weather conditions are automatically rolled on a day change.
 The "Log" function allows for notes to be recorded from the GUI, the log is stored alongside the in-game time and date for easy reference.
+
+### Campaigns
+Each campaign is handled separately and can be edited and switched between at will. 
+
+## Updating to v0.5.0
+Due to the changes to campaigns, updating to v0.5.0 while keeping saved data requires further steps to work correctly.
+1. Backup db.pkl and log.txt from your install directory to a separate location
+2. Replace the old install with the new release version
+3. Run "DnD_Time_Manager.exe" and name your campaign
+4. Click "Open Log" to ensure a log file exists for this campaign
+5. Access the campaign directory through: File → Open save directory... → [campaign name]
+6. Replace the pkl and txt files found in this directory with the ones backed up in Step 1. Ensure that the old files renamed to match the newly created ones.
+7. Close and reopen "DnD_Time_Manager.exe"
 
 ## Disclaimer
 This is an unofficial piece of software and is in no way endorsed or sponsored by [Wizards of the Coast](https://company.wizards.com/)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ At present D&DTM is only available  as a standalone .zip archive for Microsoft W
 
 ## Usage
 To start the program, run "DnD_Time_Manager.exe". This will present you with the app's GUI:
-![GUI_v0.5.0](https://github.com/JP-Carr/DnD_Time_Manager/blob/media/Images/GUI/GUI_0.5.0.JPG)
+![GUI_v0.5.0](https://github.com/JP-Carr/DnD_Time_Manager/blob/media/Images/GUI/v0.5.0/GUI_0.5.0_Default.JPG)
 #### Layout
 * Row 1 - In-game time: Time(hh:mm), Day, Tenday, Month, Year
 * Row 2 - Temperature and precipitation level

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 D&D Time Manager is a simple application created for Microsoft Windows to allow Dungeon Masters to keep track of in-game events and the times at which they occured. It also automates the rolling of local weather conditions as outlined in ch. 5 of the the Dungeon Master's Guide (with a few small tweaks).
 
 ## Installation
-At present D&DTM is only available  as a standalone .zip archive for Microsoft Windows. Download the [Latest Release](https://github.com/JP-Carr/DnD_Time_Manager/releases/latest), simply unzip the archive in your chosen directory and you're good to go.
+At present D&DTM is only available  as a standalone .zip archive for Microsoft Windows. Download the [Latest Release](https://github.com/JP-Carr/DnD_Time_Manager/releases/latest), simply unzip the archive in your chosen directory and you're good to go. If you are updating from and old version of D&DTM, ensure you don't erase/overwrite your database (db.pkl) and your log file (log.txt) unless you want a fresh install.
 
 ## Usage
 To start the program, run "DnD_Time_Manager.exe". This will present you with the app's GUI:

--- a/condition_lists.py
+++ b/condition_lists.py
@@ -5,12 +5,3 @@ wind_speed=["None" for i in range(12)]+["Light" for i in range(5)]+["Strong" for
 precipitation=["None" for i in range(12)]+["Light" for i in range(5)]+["Heavy" for i in range(3)]
 temp=["Normal for season" for i in range(14)]+[str(round((randint(1,4)*10)/1.8))+"°C colder than normal" for i in range(3)]+[str(round((randint(1,4)*10)/1.8))+"°C hotter than normal" for i in range(3)]
 months=["Hammer (Deepwinter)", "Alturiak (The Claw of Winter)", "Ches (The Claw of the Sunsets)", "Tarsakh (The Claw of the Storms)", "Mirtul (The Melting)", "Kythorn (The Time Of Flowers)", "Flamerule (Sumertide)", "Eleasias (Highsun)", "Eleint (The Fading)", "Marpenoth (Leafall)", "Uktar (The Rotting)", "Nightal (The Drawing Down)"]
-
-#x=randint(0, len(temp)-1)
-#print(temp[x])
-
-#x=1+"1"
-#x=[randint(0,1) for i in range(3)]
-#print(len(x))
-
-#print(int(15.6))

--- a/custom_themes.py
+++ b/custom_themes.py
@@ -1,0 +1,152 @@
+import PySimpleGUI as sg 
+
+sg.LOOK_AND_FEEL_TABLE["Default"] = {"BACKGROUND": "#c73032",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("black", "#ffffff"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Artificer"] = {"BACKGROUND": "#a8a0a0",
+                                        "TEXT": "#000000",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#a16d37"),
+                                        "PROGRESS": ("#01826B", "#d59139"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Barbarian"] = {"BACKGROUND": "#3b3638",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#e7623e"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Bard"] = {"BACKGROUND": "#ab6dac",
+                                        "TEXT": "#000000",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#113685"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Cleric"] = {"BACKGROUND": "#91a1b2",
+                                        "TEXT": "#000000",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#4e535e"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Druid"] = {"BACKGROUND": "#4f4026",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#7a853b"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Fighter"] = {"BACKGROUND": "#9c0202",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#7f513e"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Monk"] = {"BACKGROUND": "#666666",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("black", "#51a5c5"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Paladin"] = {"BACKGROUND": "#40469c",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#b59e54"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Ranger"] = {"BACKGROUND": "#828282",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#507f62"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Rogue"] = {"BACKGROUND": "#171717",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#555752"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Sorcerer"] = {"BACKGROUND": "#991e2e",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#828282"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Warlock"] = {"BACKGROUND": "#292929",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("white", "#7b469b"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+sg.LOOK_AND_FEEL_TABLE["Wizard"] = {"BACKGROUND": "#2a50a1",
+                                        "TEXT": "#ffffff",
+                                        "INPUT": "#ffffff",
+                                        "TEXT_INPUT": "#000000",
+                                        "SCROLL": "#c7e78b", #not edited yet
+                                        "BUTTON": ("black", "#b2bcd6"),
+                                        "PROGRESS": ("#01826B", "#D0D0D0"), #not edited yet
+                                        "BORDER": 1, "SLIDER_DEPTH": 0, "PROGRESS_DEPTH": 0, #not edited yet
+                                        }
+
+themes=["Default", "Artificer", "Barbarian", "Bard", "Cleric", "Druid", "Fighter", "Monk", "Paladin", "Ranger", "Rogue", "Sorcerer", "Warlock", "Wizard"]
+
+if __name__=="__main__":  
+    
+    theme=themes[1]
+    print(theme)
+    # Switch to use your newly created theme
+    sg.theme(theme)
+    # Call a popup to show what the theme looks like
+    sg.popup_get_text("This how the \"{}\" custom theme looks".format(theme))   

--- a/default_pref.py
+++ b/default_pref.py
@@ -1,4 +1,4 @@
 new_pref={"last campaign": [],
-          "theme": None
-      
+          "theme": "Default",
+          "new_theme": "Default"
       }

--- a/error.py
+++ b/error.py
@@ -8,4 +8,3 @@ def error(message):
     error_log.close()
     return
     
-error("test")

--- a/window_layouts.py
+++ b/window_layouts.py
@@ -3,6 +3,7 @@ from time import sleep
 from os import listdir, mkdir
 from database_class import db, pickler
 from sys import exit
+import custom_themes
 
 QT_ENTER_KEY1 =  'special 16777220'
 QT_ENTER_KEY2 =  'special 16777221'
@@ -100,9 +101,42 @@ def create_campaign(first=False, theme=None):
                 alert_box(text="\"{}\" is not a valid campaign name".format(name))
                 pass
                 
-def pref_window(theme=None):
-    themes=[None, "Black", "DarkRed1"]
+def pref_window(pref, theme=None):
+    sg.theme(theme)
+  #  themes=["Default", "Black", "DarkRed1", "SandyBeach"]
+    #themes=["Black", "BlueMono", "BluePurple", "BrightColors", "BrownBlue", "Dark", "Dark2", "DarkAmber", "DarkBlack", "DarkBlack1", "DarkBlue", "DarkBlue1", "DarkBlue10", "DarkBlue11", "DarkBlue12", "DarkBlue13", "DarkBlue14", "DarkBlue15", "DarkBlue16", "DarkBlue17", "DarkBlue2", "DarkBlue3", "DarkBlue4", "DarkBlue5", "DarkBlue6", "DarkBlue7", "DarkBlue8", "DarkBlue9", "DarkBrown", "DarkBrown1", "DarkBrown2", "DarkBrown3", "DarkBrown4", "DarkBrown5", "DarkBrown6", "DarkGreen", "DarkGreen1", "DarkGreen2", "DarkGreen3", "DarkGreen4", "DarkGreen5", "DarkGreen6", "DarkGrey", "DarkGrey1", "DarkGrey2", "DarkGrey3", "DarkGrey4", "DarkGrey5", "DarkGrey6", "DarkGrey7", "DarkPurple", "DarkPurple1", "DarkPurple2", "DarkPurple3", "DarkPurple4", "DarkPurple5", "DarkPurple6", "DarkRed", "DarkRed1", "DarkRed2", "DarkTanBlue", "DarkTeal", "DarkTeal1", "DarkTeal10", "DarkTeal11", "DarkTeal12", "DarkTeal2", "DarkTeal3", "DarkTeal4", "DarkTeal5", "DarkTeal6", "DarkTeal7", "DarkTeal8", "DarkTeal9", "Default", "Default1", "DefaultNoMoreNagging", "Green", "GreenMono", "GreenTan", "HotDogStand", "Kayak", "LightBlue", "LightBlue1", "LightBlue2", "LightBlue3", "LightBlue4", "LightBlue5", "LightBlue6", "LightBlue7", "LightBrown", "LightBrown1", "LightBrown10", "LightBrown11", "LightBrown12", "LightBrown13", "LightBrown2", "LightBrown3", "LightBrown4", "LightBrown5", "LightBrown6", "LightBrown7", "LightBrown8", "LightBrown9", "LightGray1", "LightGreen", "LightGreen1", "LightGreen10", "LightGreen2", "LightGreen3", "LightGreen4", "LightGreen5", "LightGreen6", "LightGreen7", "LightGreen8", "LightGreen9", "LightGrey", "LightGrey1", "LightGrey2", "LightGrey3", "LightGrey4", "LightGrey5", "LightGrey6", "LightPurple", "LightTeal", "LightYellow", "Material1", "Material2", "NeutralBlue", "Purple", "Reddit", "Reds", "SandyBeach", "SystemDefault", "SystemDefault1", "SystemDefaultForReal", "Tan", "TanBlue", "TealMono", "Topanga"]
+    themes=custom_themes.themes
+    theme_len=0
+    for i in themes:
+        if len(i)>theme_len:
+            theme_len=len(i)
     
+    
+    layout=[
+           # [sg.Text("saewfafffffffffffffffffffffffffffffff")],
+            [sg.Text("Theme (requires restart)"), sg.Combo(themes, key="themes", size=(theme_len+2, 1), default_value=theme)],
+            [sg.Button("Save"), sg.Button("Cancel")]
+            ]
+    window=sg.Window("Preferences", layout, finalize=True, icon=icon_path, element_justification="center", force_toplevel=True,disable_minimize=False)
+  
+    while True:
+        event, values = window.read()
+        if event == sg.WIN_CLOSED or event=="Cancel":
+            save=False
+            break
+        
+        elif event=="Save":
+            save=True
+            if window["themes"].Get() in themes:
+                pref["new_theme"]=window["themes"].Get()
+            
+                
+            print(pref["theme"])
+            break
+        
+    window.close()        
+    return pref, save
+            
     
 def rename_window(old_name, theme=None):
     sg.theme(theme)
@@ -127,7 +161,7 @@ def rename_window(old_name, theme=None):
             if active_element==window["campaign_name"]:
                 focused_enter="campaign_name"
         
-        if event == sg.WIN_CLOSED:
+        if event == sg.WIN_CLOSED or event=="Cancel":
             window.close()
             return 
 
@@ -140,6 +174,26 @@ def rename_window(old_name, theme=None):
                 if name in listdir():                 
                     alert_box(text="Campaign \"{}\" already exists".format(name))
                     pass
+                
+def test_window(theme=None):
+    sg.theme(theme)
+    c1=[sg.Button("Confirm"), sg.Button("Cancel")]
+    layout=[
+            [sg.Text("test")],
+            [sg.HorizontalSeparator(color="gray")],
+            [sg.Text("New name"), sg.InputText("", size=(25,1), key="campaign_name")],
+            #[sg.Button("Confirm"), sg.Button("Cancel")],
+            [sg.Column(c1)]
+            ]
+    
+    window=sg.Window("Preferences", layout, finalize=True, icon=icon_path, element_justification="center", force_toplevel=True,disable_minimize=False)
+  
+    while True:
+        event, values = window.read()
+        if event == sg.WIN_CLOSED:
+            break
+    window.close()
+    
+if __name__=="__main__":  
                     
-        elif event=="Cancel":
-            window.close()
+    test_window()

--- a/window_layouts.py
+++ b/window_layouts.py
@@ -113,7 +113,8 @@ def pref_window(pref, theme=None):
     
     
     layout=[
-           # [sg.Text("saewfafffffffffffffffffffffffffffffff")],
+            [sg.Text("Appearance")],
+            [sg.HorizontalSeparator()],
             [sg.Text("Theme (requires restart)"), sg.Combo(themes, key="themes", size=(theme_len+2, 1), default_value=theme)],
             [sg.Button("Save"), sg.Button("Cancel")]
             ]
@@ -177,13 +178,13 @@ def rename_window(old_name, theme=None):
                 
 def test_window(theme=None):
     sg.theme(theme)
-    c1=[sg.Button("Confirm"), sg.Button("Cancel")]
+  #  c1=[sg.Button("Confirm"), sg.Button("Cancel")]
     layout=[
             [sg.Text("test")],
             [sg.HorizontalSeparator(color="gray")],
             [sg.Text("New name"), sg.InputText("", size=(25,1), key="campaign_name")],
             #[sg.Button("Confirm"), sg.Button("Cancel")],
-            [sg.Column(c1)]
+     
             ]
     
     window=sg.Window("Preferences", layout, finalize=True, icon=icon_path, element_justification="center", force_toplevel=True,disable_minimize=False)


### PR DESCRIPTION
Multicampaign  Rework
- added the ability to switch between campaigns with separate databases and logs
    - campaign creation/deletion
    - campaign rename
    - load recent campaigns
- added menu bar to contain campaign switching functions and links to github
- added icons to auxiliary windows 
- new class to manage database
- added preferences file to keep settings cross-campaign 

Window Style
- added 14 custom themes 
- new preferences window allows for switching between themes (requires restart)

Readme
- updates to account for the above changes
- addresses updating to v0.5.0